### PR TITLE
Make Mario transparent

### DIFF
--- a/sprites.py
+++ b/sprites.py
@@ -6,7 +6,7 @@ class sprites():
         self.CharacterSpritesheet = sprite.spritesheet('img/characters.gif',16)
         self.TilesSpritesheet = sprite.spritesheet('img/tiles.png',16)
         #sprites
-        self.mario = self.CharacterSpritesheet.image_at((276, 44, 16, 16),4)
+        self.mario = self.CharacterSpritesheet.image_at((276, 44, 16, 16),4, colorkey=-1)
         self.sky = self.TilesSpritesheet.image_at((48, 368, 16, 16),2)
         self.bricks = self.TilesSpritesheet.image_at((16,0,16,16),2)
         self.ground = self.TilesSpritesheet.image_at((0,0,16,16),2)


### PR DESCRIPTION
Uses the `colorkey` parameter to enable transparency.

Fixes #1.