### PR TITLE
Keyboard Up Jump

### DIFF
--- a/classes/Input.py
+++ b/classes/Input.py
@@ -22,7 +22,7 @@ class Input():
             self.entity.traits['goTrait'].direction = 1
         else:
             self.entity.traits['goTrait'].direction = 0
-        if(pressedKeys[K_SPACE]):
+        if(pressedKeys[K_SPACE]) or (pressedKeys[K_UP]):
             self.entity.traits['jumpTrait'].start()
         if(pressedKeys[K_LSHIFT]):
             self.entity.traits['goTrait'].boost = True


### PR DESCRIPTION
Added keyboard up button as jump option, in response to space bar not working in issue #32 

Per [Pygame documentation](https://www.pygame.org/docs/ref/key.html#comment_pygame_key_get_pressed):

> 
>  2007-02-08T19:53:05 - Anonymous
> 
> Depending on your keyboard there may be limitations of how many simultaneous keypresses can be detected by this command. Some combinations will work on one keyboard and not on another.

On some keyboards, arrow keys take priority over spacebar.