### PR TITLE
Added attributes to entity class to make dealing with Koopa easier

### DIFF
--- a/entities/EntityBase.py
+++ b/entities/EntityBase.py
@@ -10,6 +10,8 @@ class EntityBase(object):
         self.gravity = gravity
         self.traits = None
         self.alive = True
+        self.active = True
+        self.bouncing = False
         self.timeAfterDeath = 5
         self.timer = 0
         self.type = ""

--- a/entities/Goomba.py
+++ b/entities/Goomba.py
@@ -70,6 +70,6 @@ class Goomba(EntityBase):
                     self._onCollisionWithMob(ent, collisionState)
 
     def _onCollisionWithMob(self, mob, collisionState):
-        if collisionState.isColliding and mob.alive == "shellBouncing":
+        if collisionState.isColliding and mob.bouncing:
             self.alive = False
             self.sound.play_sfx(self.sound.brick_bump)

--- a/entities/Koopa.py
+++ b/entities/Koopa.py
@@ -30,13 +30,13 @@ class Koopa(EntityBase):
         self.sound = sound
 
     def update(self, camera):
-        if self.alive is True:
+        if self.alive and self.active:
             self.updateAlive(camera)
             self.checkEntityCollision()
-        elif self.alive == "sleeping":
+        elif self.alive and not self.active and not self.bouncing:
             self.sleepingInShell(camera)
             self.checkEntityCollision()
-        elif self.alive == "shellBouncing":
+        elif self.bouncing:
             self.shellBouncing(camera)
 
     def drawKoopa(self, camera):
@@ -65,6 +65,8 @@ class Koopa(EntityBase):
             )
         else:
             self.alive = True
+            self.active = True
+            self.bouncing = False
             self.timer = 0
         self.timer += 0.1
 
@@ -83,6 +85,6 @@ class Koopa(EntityBase):
                         self._onCollisionWithMob(ent, collisionState)
 
     def _onCollisionWithMob(self, mob, collisionState):
-        if collisionState.isColliding and mob.alive == "shellBouncing":
+        if collisionState.isColliding and mob.bouncing:
             self.alive = False
             self.sound.play_sfx(self.sound.brick_bump)

--- a/entities/Mario.py
+++ b/entities/Mario.py
@@ -35,7 +35,7 @@ bigAnimation = Animation(
 
 
 class Mario(EntityBase):
-    def __init__(self, x, y, level, screen, dashboard, sound, gravity=0.75):
+    def __init__(self, x, y, level, screen, dashboard, sound, gravity=0.8):
         super(Mario, self).__init__(x, y, gravity)
         self.camera = Camera(self.rect, self)
         self.sound = sound
@@ -103,18 +103,19 @@ class Mario(EntityBase):
             self.powerup(1)
             self.killEntity(mob)
             self.sound.play_sfx(self.sound.powerup)
-        elif collisionState.isTop and (mob.alive or mob.alive == "shellBouncing"):
+        elif collisionState.isTop and (mob.alive or mob.bouncing):
             self.sound.play_sfx(self.sound.stomp)
             self.rect.bottom = mob.rect.top
             self.bounce()
             self.killEntity(mob)
-        elif collisionState.isTop and mob.alive == "sleeping":
+        elif collisionState.isTop and mob.alive and not mob.active:
             self.sound.play_sfx(self.sound.stomp)
             self.rect.bottom = mob.rect.top
             mob.timer = 0
             self.bounce()
             mob.alive = False
-        elif collisionState.isColliding and mob.alive == "sleeping":
+        elif collisionState.isColliding and mob.alive and not mob.active and not mob.bouncing:
+            mob.bouncing = True
             if mob.rect.x < self.rect.x:
                 mob.leftrightTrait.direction = -1
                 mob.rect.x += -5
@@ -123,7 +124,6 @@ class Mario(EntityBase):
                 mob.rect.x += 5
                 mob.leftrightTrait.direction = 1
                 self.sound.play_sfx(self.sound.kick)
-            mob.alive = "shellBouncing"
         elif collisionState.isColliding and mob.alive and not self.invincibilityFrames:
             if self.powerUpState == 0:
                 self.gameOver()
@@ -144,7 +144,9 @@ class Mario(EntityBase):
         else:
             ent.timer = 0
             ent.leftrightTrait.speed = 1
-            ent.alive = "sleeping"
+            ent.alive = True
+            ent.active = False
+            ent.bouncing = False
         self.dashboard.points += 100
 
     def gameOver(self):

--- a/traits/jump.py
+++ b/traits/jump.py
@@ -1,16 +1,16 @@
 class JumpTrait:
     def __init__(self, entity):
-        self.vertical_speed = -12
+        self.verticalSpeed = -12
         self.jumpHeight = 120
         self.entity = entity
         self.initalHeight = 384
-        self.deaccelerationHeight = self.jumpHeight - ((self.vertical_speed*self.vertical_speed)/(2*self.entity.gravity))
+        self.deaccelerationHeight = self.jumpHeight - ((self.verticalSpeed*self.verticalSpeed)/(2*self.entity.gravity))
 
     def jump(self, jumping):
         if jumping:
             if not self.entity.inAir and not self.entity.inJump:  # redundant check
                 self.entity.sound.play_sfx(self.entity.sound.jump)
-                self.entity.vel.y = self.vertical_speed
+                self.entity.vel.y = self.verticalSpeed
                 self.entity.inAir = True
                 self.initalHeight = self.entity.rect.y
                 self.entity.inJump = True


### PR DESCRIPTION
Modified the entity class and added two new attributes namely:

- entity.active
- entity.bouncing

This replaces the former `self.alive == "sleeping"` and `self.alive == "shellBouncing"` for the Koopa class thus eliminating confusion for the future and making it more intuitive to work with the class.

`self.alive == "sleeping"` is now defined by:
<pre>
self.alive=True 
self.active=False
self.bouncing=False
</pre>

`self.alive == "shellBouncing"` is now defined by:
<pre>
self.alive=True
self.active=False
self.bouncing=True
</pre>

All relevant changes have been made and therefore `self.alive` will no longer take string values and will deal with Boolean values only.