### PR TITLE
Mario should only be able to jump while on the ground

### DIFF
--- a/traits/jump.py
+++ b/traits/jump.py
@@ -8,7 +8,7 @@ class JumpTrait:
 
     def jump(self, jumping):
         if jumping:
-            if not self.entity.inAir and not self.entity.inJump:  # redundant check
+            if self.entity.onGround and not self.entity.inJump:  # redundant check
                 self.entity.sound.play_sfx(self.entity.sound.jump)
                 self.entity.vel.y = self.verticalSpeed
                 self.entity.inAir = True


### PR DESCRIPTION
Fixes https://github.com/mx0c/super-mario-python/issues/95

Previously the property `inAir` was checked but it doesn't get updated when walking of an edge. `onGround` however seems to be more suitable here as it gets directly updated by the collider and seems to be correct all the time.