### PR TITLE
"Game Over" SFX fix and fix for #94

### DIFF
--- a/entities/Koopa.py
+++ b/entities/Koopa.py
@@ -51,7 +51,7 @@ class Koopa(EntityBase):
             )
 
     def shellBouncing(self, camera):
-        self.leftrightTrait.speed = 4
+        self.leftrightTrait.speed = 6
         self.applyGravity()
         self.animation.image = self.spriteCollection.get("koopa-hiding").image
         self.drawKoopa(camera)

--- a/entities/Koopa.py
+++ b/entities/Koopa.py
@@ -51,7 +51,7 @@ class Koopa(EntityBase):
             )
 
     def shellBouncing(self, camera):
-        self.leftrightTrait.speed = 6
+        self.leftrightTrait.speed = 5
         self.applyGravity()
         self.animation.image = self.spriteCollection.get("koopa-hiding").image
         self.drawKoopa(camera)

--- a/entities/Mario.py
+++ b/entities/Mario.py
@@ -121,8 +121,8 @@ class Mario(EntityBase):
                 mob.rect.x += -5
                 self.sound.play_sfx(self.sound.kick)
             else:
-                mob.rect.x += 5
                 mob.leftrightTrait.direction = 1
+                mob.rect.x += 5
                 self.sound.play_sfx(self.sound.kick)
         elif collisionState.isColliding and mob.alive and not self.invincibilityFrames:
             if self.powerUpState == 0:
@@ -131,6 +131,7 @@ class Mario(EntityBase):
                 self.powerUpState = 0
                 self.traits['goTrait'].updateAnimation(smallAnimation)
                 x, y = self.rect.x, self.rect.y
+
                 self.rect = pygame.Rect(x, y + 32, 32, 32)
                 self.invincibilityFrames = 60
                 self.sound.play_sfx(self.sound.pipe)

--- a/entities/Mario.py
+++ b/entities/Mario.py
@@ -154,7 +154,7 @@ class Mario(EntityBase):
         srf.set_colorkey((255, 255, 255), pygame.RLEACCEL)
         srf.set_alpha(128)
         self.sound.music_channel.stop()
-        self.sound.music_channel.play(self.sound.death)
+        self.sound.play_sfx(self.sound.death)
 
         for i in range(500, 20, -2):
             srf.fill((0, 0, 0))


### PR DESCRIPTION
Noticed that the "Game Over" SFX still plays even though I have disabled any sounds from the settings. That is fixed under "c1b8757719e0dec3ef0952d40cbede2fcd07831c".

Increased the Koopa speed when hidden to avoid Mario running into it right after kicking the shell.